### PR TITLE
Fix: Update deployment workflow to correctly build the dashboard

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
         run: python scripts/fetch_data.py
 
       - name: Build Panel app
-        run: panel convert src/dashboard.py --to pyodide-worker --out public/dashboard
+        run: python build.py
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
The previous workflow was incorrectly using `panel convert` on the source python file instead of running the `build.py` script. This resulted in the dashboard not being built correctly and the `dashboard_data.json` file not being included in the deployment.

This commit fixes the workflow by running `python build.py` which generates the correct `dashboard.html` file with the data embedded.