### PR TITLE
I've fixed the CI error by correcting the path to ena_data.json.

### DIFF
--- a/ena-explorer/src/lib.rs
+++ b/ena-explorer/src/lib.rs
@@ -1,6 +1,6 @@
 use wasm_bindgen::prelude::*;
 
-const ENA_DATA: &str = include_str!("../ena_data.json");
+const ENA_DATA: &str = include_str!("../../ena_data.json");
 
 #[wasm_bindgen]
 pub fn get_ena_data() -> String {


### PR DESCRIPTION
The build was failing in CI because the path to `ena_data.json` in `ena-explorer/src/lib.rs` was incorrect. I've corrected the path from `../ena_data.json` to `../../ena_data.json`.