### PR TITLE
I will fix the 404 error by correcting the path to `ena_explorer.js`.

### DIFF
--- a/ena-explorer/index.html
+++ b/ena-explorer/index.html
@@ -6,7 +6,7 @@
   </head>
   <body>
     <script type="module">
-      import init, { get_ena_data } from './pkg/ena_explorer.js';
+      import init, { get_ena_data } from './ena_explorer.js';
 
       async function run() {
         await init();


### PR DESCRIPTION
The `index.html` file was trying to load the `ena_explorer.js` module from an incorrect path, resulting in a 404 error. I will correct the path to point to the correct location.