### PR TITLE
The CI was failing because the directory `assets/data/chunks` did not…

### DIFF
--- a/.github/workflows/update_samples.yml
+++ b/.github/workflows/update_samples.yml
@@ -21,6 +21,9 @@ jobs:
     - name: Install dependencies
       run: pip install requests
 
+    - name: Create data directories
+      run: mkdir -p genome-dashboard/assets/data/chunks
+
     - name: Run data extraction
       run: python genome-dashboard/extract_ena_genomes.py
 


### PR DESCRIPTION
… exist. This commit fixes the issue by creating the directory before running the scripts.