### PR TITLE
feat: Create a landing page for WGS/MGx selection

### DIFF
--- a/genome-dashboard/dashboard.html
+++ b/genome-dashboard/dashboard.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Genome Dashboard</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css" rel="stylesheet">
+  <link href="assets/styles.css" rel="stylesheet">
+</head>
+<body class="container mt-4">
+  <div id="loading-overlay">
+    <div class="progress">
+      <div id="progress-bar" class="progress-bar" role="progressbar" style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">0%</div>
+    </div>
+  </div>
+  <h1 id="dashboard-title" class="mb-4"></h1>
+
+  <div class="row mb-3">
+    <div class="col-md-6">
+      <input id="organism-filter" class="form-control" placeholder="🔎 Filter by organism name..." />
+    </div>
+    <div class="col-md-6">
+      <select id="tech-filter" class="form-select">
+        <option value="">All Technologies</option>
+        <option value="OXFORD_NANOPORE">Oxford Nanopore</option>
+        <option value="PACBIO_SMRT">PacBio</option>
+      </select>
+    </div>
+  </div>
+
+  <div id="stats" class="mb-4"></div>
+  <div id="plots" class="row mb-4 hidden">
+    <div id="reads-plot" class="col-md-6"></div>
+    <div id="bases-plot" class="col-md-6"></div>
+  </div>
+  <div class="row mb-3">
+    <div class="col-md-12">
+      <button id="download-tsv" class="btn btn-primary">Download TSV</button>
+      <button id="download-xlsx" class="btn btn-primary">Download XLSX</button>
+    </div>
+  </div>
+  <div id="genome-table" class="hidden"></div>
+
+  <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+  <script type="text/javascript" src="https://oss.sheetjs.com/sheetjs/xlsx.full.min.js"></script>
+  <script src="https://cdn.plot.ly/plotly-2.20.0.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/fflate@0.7.4/umd/index.js"></script>
+  <script type="module" src="scripts/dashboard.js"></script>
+</body>
+</html>

--- a/genome-dashboard/index.html
+++ b/genome-dashboard/index.html
@@ -3,55 +3,32 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Genome Dashboard</title>
+  <title>Welcome to the Genome Dashboard</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css" rel="stylesheet">
   <link href="assets/styles.css" rel="stylesheet">
+  <style>
+    body {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 100vh;
+      background-color: #f8f9fa;
+    }
+    .landing-container {
+      text-align: center;
+    }
+    .btn-custom {
+      margin: 10px;
+      padding: 20px 40px;
+      font-size: 1.5rem;
+    }
+  </style>
 </head>
-<body class="container mt-4">
-  <div id="loading-overlay">
-    <div class="progress">
-      <div id="progress-bar" class="progress-bar" role="progressbar" style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">0%</div>
-    </div>
+<body>
+  <div class="landing-container">
+    <h1 class="mb-4">Select a Dashboard</h1>
+    <a href="dashboard.html?type=wgs" class="btn btn-primary btn-custom">WGS Dashboard</a>
+    <a href="dashboard.html?type=mgx" class="btn btn-secondary btn-custom">MGx Dashboard</a>
   </div>
-  <h1 class="mb-4">Oxford Nanopore & PacBio Genome Dataset</h1>
-
-  <div class="row mb-3">
-    <div class="col-md-4">
-      <select id="data-source-filter" class="form-select">
-        <option value="bacteria">Bacteria (WGS)</option>
-        <option value="metagenome">Metagenome (MGx)</option>
-      </select>
-    </div>
-    <div class="col-md-4">
-      <input id="organism-filter" class="form-control" placeholder="🔎 Filter by organism name..." />
-    </div>
-    <div class="col-md-4">
-      <select id="tech-filter" class="form-select">
-        <option value="">All Technologies</option>
-        <option value="OXFORD_NANOPORE">Oxford Nanopore</option>
-        <option value="PACBIO_SMRT">PacBio</option>
-      </select>
-    </div>
-  </div>
-
-  <div id="stats" class="mb-4"></div>
-  <div id="plots" class="row mb-4 hidden">
-    <div id="reads-plot" class="col-md-6"></div>
-    <div id="bases-plot" class="col-md-6"></div>
-  </div>
-  <div class="row mb-3">
-    <div class="col-md-12">
-      <button id="download-tsv" class="btn btn-primary">Download TSV</button>
-      <button id="download-xlsx" class="btn btn-primary">Download XLSX</button>
-    </div>
-  </div>
-  <div id="genome-table" class="hidden"></div>
-
-  <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
-  <script type="text/javascript" src="https://oss.sheetjs.com/sheetjs/xlsx.full.min.js"></script>
-  <script src="https://cdn.plot.ly/plotly-2.20.0.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/fflate@0.7.4/umd/index.js"></script>
-  <script type="module" src="scripts/dashboard.js"></script>
 </body>
 </html>

--- a/genome-dashboard/scripts/dashboard.js
+++ b/genome-dashboard/scripts/dashboard.js
@@ -1,4 +1,16 @@
 document.addEventListener("DOMContentLoaded", () => {
+  const urlParams = new URLSearchParams(window.location.search);
+  const dataType = urlParams.get('type') || 'wgs'; // Default to wgs
+
+  const dashboardTitle = document.getElementById("dashboard-title");
+  if (dataType === 'wgs') {
+    document.title = "WGS Dashboard";
+    dashboardTitle.textContent = 'WGS Dashboard';
+  } else if (dataType === 'mgx') {
+    document.title = "MGx Dashboard";
+    dashboardTitle.textContent = 'MGx Dashboard';
+  }
+
   const table = new Tabulator("#genome-table", {
     data: [],
     layout: "fitColumns",
@@ -21,7 +33,6 @@ document.addEventListener("DOMContentLoaded", () => {
   const loadingOverlay = document.getElementById("loading-overlay");
   const organismFilter = document.getElementById("organism-filter");
   const techFilter = document.getElementById("tech-filter");
-  const dataSourceFilter = document.getElementById("data-source-filter");
 
   let allData = [];
 
@@ -69,9 +80,6 @@ document.addEventListener("DOMContentLoaded", () => {
 
   organismFilter.addEventListener("input", updateFilters);
   techFilter.addEventListener("change", updateFilters);
-  dataSourceFilter.addEventListener("change", (event) => {
-    loadData(event.target.value);
-  });
 
   table.on("dataFiltered", function(filters, rows) {
     const filteredData = rows.map(row => row.getData());
@@ -80,7 +88,8 @@ document.addEventListener("DOMContentLoaded", () => {
     createBoxPlot(filteredData, "bases-plot", "base_count", "Number of Bases per Organism");
   });
 
-  loadData(dataSourceFilter.value);
+  const initialSource = dataType === 'wgs' ? 'bacteria' : 'metagenome';
+  loadData(initialSource);
 
   document.getElementById("download-tsv").addEventListener("click", () => table.download("tsv", "data.tsv"));
   document.getElementById("download-xlsx").addEventListener("click", () => table.download("xlsx", "data.xlsx", { sheetName: "My Data" }));


### PR DESCRIPTION
This commit introduces a new landing page that allows you to choose between the WGS and MGx dashboards.

- A new `index.html` is created as the landing page with buttons for WGS and MGx.
- The original `index.html` is renamed to `dashboard.html` and now serves as the template for both dashboards.
- The dashboard's JavaScript is updated to read a `type` query parameter from the URL (`wgs` or `mgx`) to load the appropriate dataset.
- The dropdown for selecting the data source has been removed from the dashboard page.