### PR TITLE
fix: Ensure consistent date types in plot generation

### DIFF
--- a/genome-dashboard/generate_plot.py
+++ b/genome-dashboard/generate_plot.py
@@ -144,7 +144,7 @@ def main():
                         count, line = parse_sample_count_from_log(log_content, mgx_count_pattern)
                         if line: new_data[run['id']]['mgx_samples'] = count
 
-            new_data[run['id']]['date'] = datetime.strptime(run["created_at"], "%Y-%m-%dT%H:%M:%SZ").date()
+            new_data[run['id']]['date'] = datetime.strptime(run["created_at"], "%Y-%m-%dT%H:%M:%SZ").strftime("%Y-%m-%d")
 
         if new_data:
             print(f"Adding {len(new_data)} new data points to {csv_file}.")
@@ -156,6 +156,7 @@ def main():
 
             # Combine old and new data
             df_combined = pd.concat([df_existing, df_new], ignore_index=True)
+            df_combined['date'] = pd.to_datetime(df_combined['date'])
             df_combined = df_combined.sort_values(by="date").reset_index(drop=True)
             df_combined.to_csv(csv_file, index=False)
             print(f"✅ {csv_file} updated.")


### PR DESCRIPTION
This commit fixes a recurring `TypeError` in the `generate_plot.py` script. The error was caused by a mix of string and date objects in the 'date' column of the pandas DataFrame, which prevented sorting.

The script is updated to ensure that new dates are created as strings in a consistent format ('YYYY-MM-DD'). The entire 'date' column is then reliably converted to a datetime format before sorting. This prevents any type conflicts from occurring and resolves the CI failure.