### PR TITLE
fix: Rotate x-axis labels on plot

### DIFF
--- a/genome-dashboard/generate_plot.py
+++ b/genome-dashboard/generate_plot.py
@@ -85,6 +85,7 @@ def generate_plot(csv_file, output_image):
     plt.title("Number of Samples Over Time")
     plt.xlabel("Date")
     plt.ylabel("Number of Samples")
+    plt.xticks(rotation='vertical')
     plt.grid(True)
     plt.legend()
     plt.tight_layout()


### PR DESCRIPTION
This commit updates the `generate_plot.py` script to rotate the x-axis labels on the generated plot to be vertical.

This improves the readability of the plot by preventing the date labels from overlapping, especially when there are many data points.